### PR TITLE
crbug819314: Fix scrollIntoView-subframe.html

### DIFF
--- a/crbug/scrollIntoView-subframe.html
+++ b/crbug/scrollIntoView-subframe.html
@@ -7,5 +7,5 @@
     <p>This is a subframe of https://codepen.io/mustaqahmed/full/ZErBbqX</p>
     <p>You should not be auto scrolled to me.</p>
   </body>
-  <script>document.body.scrollIntoView();<\/script>
+  <script>document.body.scrollIntoView();</script>
 </html>


### PR DESCRIPTION
@mustaqahmed in [this comment](https://bugs.chromium.org/p/chromium/issues/detail?id=819314#c18), you say that "this is working as intended": that the top window isn't scrolled to the iframe.

After fixing `scrollIntoView-subframe.html` with this PR, we can see that this is NOT working as intended. See [my forked codepen](https://codepen.io/Drarig29/full/OJBopBV).

Reference: https://bugs.chromium.org/p/chromium/issues/detail?id=819314